### PR TITLE
Updating 2018 Testing Ntuples

### DIFF
--- a/SHNtupliser/test/ULSamples
+++ b/SHNtupliser/test/ULSamples
@@ -4,5 +4,24 @@
 /DoublePhoton_FlatPt-5To300/RunIIWinter19PFCalibDR-2017ConditionsFlatPU0to70_105X_mc2017_realistic_v5-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
 
 
-/DoubleElectron_FlatPt-1To300/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70ECALGT_105X_upgrade2018_realistic_IdealEcalIC_v4-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
-/DoubleElectron_FlatPt-1To300/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70RAW_105X_upgrade2018_realistic_v4-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoubleElectron_FlatPt-1To300/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70ECALGT_105X_upgrade2018_realistic_IdealEcalIC_v4-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & core2018 
+/DoubleElectron_FlatPt-1To300/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70RAW_105X_upgrade2018_realistic_v4-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 &  core2018
+/DoubleElectron_FlatPt-300To1000/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70ECALGT_105X_upgrade2018_realistic_IdealEcalIC_v4-v1/AODSIM  & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoubleElectron_FlatPt-1000To1500/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70ECALGT_105X_upgrade2018_realistic_IdealEcalIC_v4-v1/AODSIM  & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoubleElectron_FlatPt-1500To3000/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70ECALGT_105X_upgrade2018_realistic_IdealEcalIC_v4-v2/AODSIM  & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoubleElectron_FlatPt-3000To4000/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70ECALGT_105X_upgrade2018_realistic_IdealEcalIC_v4-v2/AODSIM  & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoubleElectron_FlatPt-4000To5000/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70ECALGT_105X_upgrade2018_realistic_IdealEcalIC_v4-v2/AODSIM  & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoublePhoton_FlatPt-5To300/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70ECALGT_105X_upgrade2018_realistic_IdealEcalIC_v4-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoublePhoton_FlatPt-5To300/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70RAW_105X_upgrade2018_realistic_v4-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 &  core2018
+/DoublePhoton_FlatPt-5To300/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70RAW_105X_upgrade2018_realistic_v4-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 &  core2018
+/DoublePhoton_FlatPt-300To1000/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70RAW_105X_upgrade2018_realistic_v4-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoublePhoton_FlatPt-1000To1500/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70RAW_105X_upgrade2018_realistic_v4-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoublePhoton_FlatPt-1500To3000/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70RAW_105X_upgrade2018_realistic_v4-v2/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoublePhoton_FlatPt-3000To4000/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70RAW_105X_upgrade2018_realistic_v4-v2/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoublePhoton_FlatPt-4000To5000/RunIIWinter19PFCalibDR-2018ConditionsFlatPU0to70RAW_105X_upgrade2018_realistic_v4-v2/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+
+
+/DoubleElectron_FlatPt-1To300/RunIIAutumn18DR-FlatPU0to70IdealECAL_102X_upgrade2018_realistic_forECAL_v15-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoubleElectron_FlatPt-1To300/RunIIAutumn18DR-FlatPU0to70RAW_102X_upgrade2018_realistic_v15-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & 
+/DoublePhoton_FlatPt-5To300/RunIIAutumn18DR-FlatPU0to70RAW_102X_upgrade2018_realistic_v15-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & pho102X
+/DoublePhoton_FlatPt-5To300/RunIIAutumn18DR-FlatPU0to70IdealECAL_102X_upgrade2018_realistic_forECAL_v15-v1/AODSIM & -1 & -1 & 1.0 & 1.0 & 101 & 500 & pho102X

--- a/SHNtupliser/test/crab_base.py
+++ b/SHNtupliser/test/crab_base.py
@@ -10,6 +10,7 @@ config.General.transferOutputs = True
 config.section_("JobType")
 config.JobType.pluginName = 'Analysis'
 config.JobType.psetName = 'shNtupliser_autoGen_cfg.py'
+config.JobType.maxJobRuntimeMin = 480
 #config.JobType.maxMemoryMB = 3000
 #config.JobType.numCores = 4
 #config.JobType.inputFiles=['ged_regression_20161208.db',]

--- a/TrigNtup/interface/EGRegTreeStruct.hh
+++ b/TrigNtup/interface/EGRegTreeStruct.hh
@@ -36,13 +36,29 @@ struct ClustStruct {
   }
 };
 
-
 struct EleStruct {
   float et,energy,energyErr,ecalEnergy,ecalEnergyErr,eta,phi,trkEtaMode,trkPhiMode,trkPMode,trkPModeErr,fbrem,corrMean,corrSigma,hademTow,hademCone,trkPInn,trkPtInn,trkPVtx,trkPOut,trkChi2,trkNDof,ecalDrivenSeed,nrSatCrys,scRawEnergy,scRawESEnergy;
   static std::string contents(){return "et/F:energy:energyErr:ecalEnergy:ecalEnergyErr:eta:phi:trkEtaMode:trkPhiMode:trkPMode:trkPModeErr:fbrem:corrMean:corrSigma:hademTow:hademCone:trkPInn:trkPtInn:trkPVtx:trkPOut:trkChi2:trkNDof:ecalDrivenSeed:nrSatCrys:scRawEnergy:scRawESEnergy";}
   void clear(){et=energy=energyErr=ecalEnergy=ecalEnergyErr=eta=phi=trkEtaMode=trkPhiMode=trkPMode=trkPModeErr=fbrem=corrMean=corrSigma=hademTow=hademCone=trkPInn=trkPtInn=trkPVtx=trkPOut=trkChi2=trkNDof=ecalDrivenSeed=nrSatCrys=scRawEnergy=scRawESEnergy=0.;}
   void fill(const reco::GsfElectron& ele);
 };
+
+struct EleEnergyStruct {
+  float ecalTrk,ecalTrkErr,ecal,ecalErr;
+  static std::string contents(){return "ecalTrk/F:ecalTrkErr:ecal:ecalErr";}
+  void clear(){ecalTrk=ecalTrkErr=ecal=ecalErr=0.;}
+  void fill(const reco::GsfElectron& ele){ecalTrk=ele.energy();ecalTrkErr=ele.p4Error(reco::GsfElectron::P4_COMBINATION);ecal=ele.ecalEnergy();ecalErr=ele.ecalEnergyError();}
+};
+
+struct PhoEnergyStruct {
+  float ecal,ecalErr;
+  static std::string contents(){return "ecal:ecalErr";}
+  void clear(){ecal=ecalErr=0.;}
+  void fill(const reco::Photon& pho){ecal=pho.energy();ecalErr=pho.getCorrectedEnergyError(reco::Photon::regression2);}
+
+};
+
+
 
 struct PhoStruct {
   float et,energy,energyErr,eta,phi,corrMean,corrSigma,hademTow,hademCone,nrSatCrys,scRawEnergy,scRawESEnergy;
@@ -105,9 +121,15 @@ struct EGRegTreeStruct {
   ClustStruct clus1;
   ClustStruct clus2;
   ClustStruct clus3;
+  std::vector<EleEnergyStruct> eleEnergies;
+  std::vector<PhoEnergyStruct> phoEnergies;
+
+  void setNrEnergies(unsigned int nrEleEnergies,unsigned int nrPhoEnergies){
+    eleEnergies.resize(nrEleEnergies);phoEnergies.resize(nrPhoEnergies);
+  }
   void createBranches(TTree* tree);
   void setBranchAddresses(TTree* tree);
-  void fill(const edm::Event& event,int iNrVert,float iRho,float nrPUInt,float nrTruePUInt,const EcalRecHitCollection& ecalHitsEB,const EcalRecHitCollection& ecalHitsEE,const CaloTopology& topo,const EcalChannelStatus& ecalChanStatus,const reco::SuperCluster* iSC,const reco::GenParticle* iMC,const reco::GsfElectron* iEle,const reco::Photon* iPho,const reco::SuperCluster* altSC);
+  void fill(const edm::Event& event,int iNrVert,float iRho,float nrPUInt,float nrTruePUInt,const EcalRecHitCollection& ecalHitsEB,const EcalRecHitCollection& ecalHitsEE,const CaloTopology& topo,const EcalChannelStatus& ecalChanStatus,const reco::SuperCluster* iSC,const reco::GenParticle* iMC,const reco::GsfElectron* iEle,const reco::Photon* iPho,const reco::SuperCluster* altSC,const std::vector<const reco::GsfElectron*>& altEles,const std::vector<const reco::Photon*>& altPhos );
   void clear(){
     nrVert=0;
     rho=0.;
@@ -125,6 +147,8 @@ struct EGRegTreeStruct {
     clus1.clear();
     clus2.clear();
     clus3.clear();
+    for(auto& x : eleEnergies) x.clear();
+    for(auto& x : phoEnergies) x.clear();
   }
 
 };

--- a/TrigNtup/plugins/EGRegTreeMaker.cc
+++ b/TrigNtup/plugins/EGRegTreeMaker.cc
@@ -53,6 +53,9 @@ private:
   edm::EDGetTokenT<std::vector<reco::Photon> > phosToken_;
   edm::EDGetTokenT<std::vector<PileupSummaryInfo> > puSumToken_;
 
+  std::vector<edm::EDGetTokenT<std::vector<reco::GsfElectron> > > eleAltTokens_;
+  std::vector<edm::EDGetTokenT<std::vector<reco::Photon> > > phoAltTokens_;
+
   EGRegTreeMaker(const EGRegTreeMaker& rhs)=delete;
   EGRegTreeMaker& operator=(const EGRegTreeMaker& rhs)=delete;
 
@@ -96,6 +99,9 @@ EGRegTreeMaker::EGRegTreeMaker(const edm::ParameterSet& iPara):
   setToken(elesToken_,iPara,"elesTag");
   setToken(phosToken_,iPara,"phosTag");
   setToken(puSumToken_,iPara,"puSumTag");
+  setToken(eleAltTokens_,iPara,"elesAltTag");
+  setToken(phoAltTokens_,iPara,"phosAltTag");
+
 }
 
 EGRegTreeMaker::~EGRegTreeMaker()
@@ -109,6 +115,7 @@ void EGRegTreeMaker::beginJob()
   edm::Service<TFileService> fs;
   fs->file().cd();
   egRegTree_ = new TTree("egRegTree","");
+  egRegTreeData_.setNrEnergies(eleAltTokens_.size(),phoAltTokens_.size());
   egRegTreeData_.createBranches(egRegTree_);
 } 
 
@@ -145,17 +152,34 @@ namespace{
     else if(!sc.clusters().isAvailable()) return false;
     else return true;
   }
-  const reco::GsfElectron* matchEle(unsigned int seedId,const std::vector<reco::GsfElectron>& eles){
-    for(auto& ele : eles){
-      if(ele.superCluster()->seed()->seed().rawId()==seedId) return &ele;
+  template<typename T> 
+  const T* matchBySCSeedId(unsigned int seedId,const std::vector<T>& objs){
+    for(auto& obj : objs){
+      if(obj.superCluster()->seed()->seed().rawId()==seedId) return &obj;
     }
     return nullptr;
   }
+  const reco::GsfElectron* matchEle(unsigned int seedId,const std::vector<reco::GsfElectron>& eles){
+    return matchBySCSeedId(seedId,eles);
+  }
   const reco::Photon* matchPho(unsigned int seedId,const std::vector<reco::Photon>& phos){
-    for(auto& pho : phos){
-      if(pho.superCluster()->seed()->seed().rawId()==seedId) return &pho;
+    return matchBySCSeedId(seedId,phos);
+  }
+  
+  template<typename T> std::vector<const T*> 
+  matchToAltCollsBySCSeedId(const T* objToMatch,const std::vector<edm::Handle<std::vector<T> > >& objCollHandles){
+    std::vector<const T*> matches;
+    if(objToMatch){
+      unsigned int seedId = objToMatch->superCluster()->seed()->seed().rawId();
+      for(auto& objCollHandle : objCollHandles){
+	if(objCollHandle.isValid()) matches.push_back(matchBySCSeedId(seedId,*objCollHandle));
+	else matches.push_back(nullptr);
+      }
     }
-    return nullptr;
+    else{
+      matches.resize(objCollHandles.size(),nullptr);
+    }
+    return matches;
   }
 }
 
@@ -169,7 +193,9 @@ void EGRegTreeMaker::analyze(const edm::Event& iEvent,const edm::EventSetup& iSe
   auto verticesHandle = getHandle(iEvent,verticesToken_);
   auto rhoHandle = getHandle(iEvent,rhoToken_);
   auto elesHandle = getHandle(iEvent,elesToken_);
+  auto eleAltHandles = getHandle(iEvent,eleAltTokens_);
   auto phosHandle = getHandle(iEvent,phosToken_);
+  auto phoAltHandles = getHandle(iEvent,phoAltTokens_);
   auto puSumHandle = getHandle(iEvent,puSumToken_);
   edm::ESHandle<CaloTopology> caloTopoHandle;
   iSetup.get<CaloTopologyRecord>().get(caloTopoHandle);
@@ -198,12 +224,16 @@ void EGRegTreeMaker::analyze(const edm::Event& iEvent,const edm::EventSetup& iSe
 	const reco::Photon* pho = phosHandle.isValid() ? matchPho(sc.seed()->seed().rawId(),*phosHandle) : nullptr;
 	const reco::SuperCluster* scAlt = matchSC(&sc,scAltHandles);
 	
+	const std::vector<const reco::GsfElectron*> altEles = matchToAltCollsBySCSeedId(ele,eleAltHandles);
+	const std::vector<const reco::Photon*> altPhos = matchToAltCollsBySCSeedId(pho,phoAltHandles);
+
 	if(hasBasicClusters(sc)){
 	  egRegTreeData_.fill(iEvent,nrVert,*rhoHandle,nrPUInt,nrPUIntTrue,
 			      *ecalHitsEBHandle,*ecalHitsEEHandle,
 			      *caloTopoHandle,
 			      *chanStatusHandle,
-			      &sc,genPart,ele,pho,scAlt);
+			      &sc,genPart,ele,pho,scAlt,
+			      altEles,altPhos);
 	  egRegTree_->Fill();
 	}
       }
@@ -217,12 +247,16 @@ void EGRegTreeMaker::analyze(const edm::Event& iEvent,const edm::EventSetup& iSe
 	const reco::GsfElectron* ele = elesHandle.isValid() && sc ? matchEle(sc->seed()->seed().rawId(),*elesHandle) : nullptr;
 	const reco::Photon* pho = phosHandle.isValid() && sc ? matchPho(sc->seed()->seed().rawId(),*phosHandle) : nullptr;
 	
+	const std::vector<const reco::GsfElectron*> altEles = matchToAltCollsBySCSeedId(ele,eleAltHandles);
+	const std::vector<const reco::Photon*> altPhos = matchToAltCollsBySCSeedId(pho,phoAltHandles);
+
 
 	egRegTreeData_.fill(iEvent,nrVert,*rhoHandle,nrPUInt,nrPUIntTrue,
 			    *ecalHitsEBHandle,*ecalHitsEEHandle,
 			    *caloTopoHandle,
 			    *chanStatusHandle,
-			    sc,&genPart,ele,pho,scAlt);
+			    sc,&genPart,ele,pho,scAlt,
+			    altEles,altPhos);
 	egRegTree_->Fill();
       }
     }

--- a/TrigNtup/src/EGRegTreeStruct.cc
+++ b/TrigNtup/src/EGRegTreeStruct.cc
@@ -27,6 +27,14 @@ void EGRegTreeStruct::createBranches(TTree* tree)
   tree->Branch("clus1",&clus1,clus1.contents().c_str());
   tree->Branch("clus2",&clus2,clus2.contents().c_str());
   tree->Branch("clus3",&clus3,clus3.contents().c_str());
+  for(size_t eleNr=0;eleNr<eleEnergies.size();eleNr++){
+    std::string name = "eleAltEnergy"+std::to_string(eleNr+1);
+    tree->Branch(name.c_str(),&eleEnergies[eleNr],eleEnergies[eleNr].contents().c_str());
+  }
+  for(size_t phoNr=0;phoNr<phoEnergies.size();phoNr++){
+    std::string name = "phoAltEnergy"+std::to_string(phoNr+1);
+    tree->Branch(name.c_str(),&phoEnergies[phoNr],phoEnergies[phoNr].contents().c_str());
+  }
 }
 
 void EGRegTreeStruct::setBranchAddresses(TTree* tree)
@@ -47,6 +55,15 @@ void EGRegTreeStruct::setBranchAddresses(TTree* tree)
   tree->SetBranchAddress("clus1",&clus1);
   tree->SetBranchAddress("clus2",&clus2);
   tree->SetBranchAddress("clus3",&clus3);
+  for(size_t eleNr=0;eleNr<eleEnergies.size();eleNr++){
+    std::string name = "eleAltEnergy"+std::to_string(eleNr+1);
+    tree->SetBranchAddress(name.c_str(),&eleEnergies[eleNr]);
+  }
+  for(size_t phoNr=0;phoNr<phoEnergies.size();phoNr++){
+    std::string name = "phoAltEnergy"+std::to_string(phoNr+1);
+    tree->SetBranchAddress(name.c_str(),&phoEnergies[phoNr]);
+  }
+  
 }
 
 void EvtStruct::fill(const edm::Event& event)
@@ -68,7 +85,7 @@ void GenInfoStruct::fill(const reco::GenParticle& genPart,float iDR)
 }
 
 void EGRegTreeStruct::fill(const edm::Event& event,int iNrVert,float iRho,float iNrPUInt,float iNrPUIntTrue,
-			   const EcalRecHitCollection& ecalHitsEB,const EcalRecHitCollection& ecalHitsEE,const CaloTopology& topo,const EcalChannelStatus& ecalChanStatus,const reco::SuperCluster* iSC,const reco::GenParticle* iMC,const reco::GsfElectron* iEle,const reco::Photon* iPho,const reco::SuperCluster* scAlt)
+			   const EcalRecHitCollection& ecalHitsEB,const EcalRecHitCollection& ecalHitsEE,const CaloTopology& topo,const EcalChannelStatus& ecalChanStatus,const reco::SuperCluster* iSC,const reco::GenParticle* iMC,const reco::GsfElectron* iEle,const reco::Photon* iPho,const reco::SuperCluster* scAlt, const std::vector<const reco::GsfElectron*>& altEles,const std::vector<const reco::Photon*>& altPhos)
 {
   clear();
 
@@ -104,7 +121,19 @@ void EGRegTreeStruct::fill(const edm::Event& event,int iNrVert,float iRho,float 
     pho.fill(*iPho);
     phoSSFull.fill(iPho->full5x5_showerShapeVariables());
   }
-    
+  if(altEles.size() != eleEnergies.size()){
+    throw cms::Exception("LogicError") <<" alt electrons && eleEnergies are not equal in size "<<altEles.size()<<" "<<eleEnergies.size();
+  }
+  if(altPhos.size() != phoEnergies.size()){
+    throw cms::Exception("LogicError") <<" alt photons && phosEnergies are not equal in size "<<altPhos.size()<<" "<<phoEnergies.size();
+  }
+
+  for(size_t eleNr=0;eleNr<altEles.size();eleNr++){
+    if(altEles[eleNr]) eleEnergies[eleNr].fill(*altEles[eleNr]);
+  }
+  for(size_t phoNr=0;phoNr<altPhos.size();phoNr++){
+    if(altPhos[phoNr]) phoEnergies[phoNr].fill(*altPhos[phoNr]);
+  }
 
 }
 

--- a/TrigNtup/test/egRegTreeMaker.py
+++ b/TrigNtup/test/egRegTreeMaker.py
@@ -61,7 +61,10 @@ process.egRegTreeMaker = cms.EDAnalyzer("EGRegTreeMaker",
                                         scAltTag = cms.VInputTag("particleFlowSuperClusterECALNoThres:particleFlowSuperClusterECALBarrel","particleFlowSuperClusterECALNoThres:particleFlowSuperClusterECALEndcapWithPreshower"),
                                         ecalHitsEBTag = cms.InputTag("reducedEgamma","reducedEBRecHits"),
                                         ecalHitsEETag = cms.InputTag("reducedEgamma","reducedEERecHits"),
-                                        elesTag = cms.InputTag("slimmedElectrons")
+                                        elesTag = cms.InputTag("slimmedElectrons") 
+                                        phosTag = cms.InputTag("slimmedPhotons"),
+                                        elesAltTag = cms.VInputTag()
+                                        phosAltTag = cms.VInputTag()
                                         )
 
 process.egRegTreeMaker.verticesTag = cms.InputTag("offlinePrimaryVertices")

--- a/TrigNtup/test/egRegTreeMakerNewSC.py
+++ b/TrigNtup/test/egRegTreeMakerNewSC.py
@@ -66,7 +66,10 @@ process.egRegTreeMaker = cms.EDAnalyzer("EGRegTreeMaker",
                                         scAltTag = cms.VInputTag(),
                                         ecalHitsEBTag = cms.InputTag("reducedEgamma","reducedEBRecHits"),
                                         ecalHitsEETag = cms.InputTag("reducedEgamma","reducedEERecHits"),
-                                        elesTag = cms.InputTag("slimmedElectrons")
+                                        elesTag = cms.InputTag("slimmedElectrons"),
+                                        phosTag = cms.InputTag("slimmedPhotons"),
+                                        elesAltTag = cms.VInputTag(),
+                                        phosAltTag = cms.VInputTag()
                                         )
 
 process.egRegTreeMaker.elesTag = cms.InputTag("gedGsfElectrons")

--- a/TrigNtup/test/egRegTreeMakerRefinedAOD.py
+++ b/TrigNtup/test/egRegTreeMakerRefinedAOD.py
@@ -33,8 +33,8 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condD
 from Configuration.AlCa.autoCond import autoCond
 from Configuration.AlCa.GlobalTag import GlobalTag
 if options.isMC:
-    process.GlobalTag = GlobalTag(process.GlobalTag, '105X_mc2017_realistic_v5', '')
-#    process.GlobalTag = GlobalTag(process.GlobalTag, '103X_mc2017_realistic_v1', '')
+#    process.GlobalTag = GlobalTag(process.GlobalTag, '105X_mc2017_realistic_v5', '')
+    process.GlobalTag = GlobalTag(process.GlobalTag, '105X_upgrade2018_realistic_v4', '')
 else:
     from SHarper.SHNtupliser.globalTags_cfi import getGlobalTagNameData
     globalTagName = getGlobalTagNameData(datasetVersion)
@@ -66,7 +66,9 @@ process.egRegTreeMaker = cms.EDAnalyzer("EGRegTreeMaker",
                                         ecalHitsEBTag = cms.InputTag("reducedEcalRecHitsEB"),
                                         ecalHitsEETag = cms.InputTag("reducedEcalRecHitsEE"),
                                         elesTag = cms.InputTag("gedGsfElectrons"),
-                                        phosTag = cms.InputTag("gedPhotons")
+                                        phosTag = cms.InputTag("gedPhotons"),
+                                        elesAltTag = cms.VInputTag(),
+                                        phosAltTag = cms.VInputTag(),
                                         )
 
 process.load("SHarper.TrigNtup.rePFSuperCluster_cff")

--- a/TrigNtup/test/egRegTreeMakerRefinedAODNewReg.py
+++ b/TrigNtup/test/egRegTreeMakerRefinedAODNewReg.py
@@ -1,0 +1,181 @@
+isCrabJob=False #script seds this if its a crab job
+
+# Import configurations
+import FWCore.ParameterSet.Config as cms
+import os
+import sys
+# set up process
+process = cms.Process("HEEP")
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing ('analysis') 
+options.register('isMC',True,options.multiplicity.singleton,options.varType.bool," whether we are running on MC or not")
+options.parseArguments()
+
+print options.inputFiles
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(options.inputFiles),  
+                          )
+
+
+# initialize MessageLogger and output report
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(5000),
+    limit = cms.untracked.int32(10000000)
+)
+
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
+
+#Load geometry
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+from Configuration.AlCa.autoCond import autoCond
+from Configuration.AlCa.GlobalTag import GlobalTag
+if options.isMC:
+#    process.GlobalTag = GlobalTag(process.GlobalTag, '105X_mc2017_realistic_v5', '')
+    process.GlobalTag = GlobalTag(process.GlobalTag, '105X_upgrade2018_realistic_v4', '')
+
+else:
+    from SHarper.SHNtupliser.globalTags_cfi import getGlobalTagNameData
+    globalTagName = getGlobalTagNameData(datasetVersion)
+    process.GlobalTag = GlobalTag(process.GlobalTag, globalTagName,'')
+    process.GlobalTag = GlobalTag(process.GlobalTag, '103X_dataRun2_v6_AC_v01', '')
+
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Geometry.CaloEventSetup.CaloTowerConstituents_cfi")
+process.load("Configuration.StandardSequences.Services_cff")
+
+# set the number of events
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string(options.outputFile)
+)
+
+process.egRegTreeMaker = cms.EDAnalyzer("EGRegTreeMaker",
+                                        verticesTag = cms.InputTag("offlinePrimaryVertices"),
+                                        rhoTag = cms.InputTag("fixedGridRhoFastjetAllTmp"),
+                                        genPartsTag = cms.InputTag("genParticles"),
+                                        puSumTag = cms.InputTag("addPileupInfo"),
+                                     #   scTag = cms.VInputTag("particleFlowSuperClusterECAL:particleFlowSuperClusterECALBarrel","particleFlowSuperClusterECAL:particleFlowSuperClusterECALEndcapWithPreshower"),
+                                        scTag = cms.VInputTag("particleFlowEGamma",),
+                                        scAltTag = cms.VInputTag("particleFlowSuperClusterECALNoThres:particleFlowSuperClusterECALBarrel","particleFlowSuperClusterECALNoThres:particleFlowSuperClusterECALEndcapWithPreshower"),
+                                        ecalHitsEBTag = cms.InputTag("reducedEcalRecHitsEB"),
+                                        ecalHitsEETag = cms.InputTag("reducedEcalRecHitsEE"),
+                                        elesTag = cms.InputTag("gedGsfElectrons"),
+                                        phosTag = cms.InputTag("gedPhotons"),
+                                        elesAltTag = cms.VInputTag("gedGsfElectrons::@skipCurrentProcess"),
+                                        phosAltTag = cms.VInputTag("gedPhotons::@skipCurrentProcess"),
+                                        )
+
+process.load("SHarper.TrigNtup.rePFSuperCluster_cff")
+process.load("SHarper.SHNtupliser.regressionApplicationAOD_cff")
+
+process.p = cms.Path(process.rePFSuperClusterThresSeq*process.regressionApplication*process.egRegTreeMaker)
+process.AODSIMoutput = cms.OutputModule("PoolOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(4),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('AODSIM'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    fileName = cms.untracked.string(options.outputFile.replace(".root","_EDM.root")),
+    outputCommands = cms.untracked.vstring('drop *',
+                                           "keep *_*_*_HEEP",
+                                    )                                           
+                                   )
+#process.out = cms.EndPath(process.AODSIMoutput)
+
+
+def readEleRegresFromDBFile(process,filename=None,suffex="2017UL",prod=False):
+    print "reading in ele regression with tag {} from prod {}".format(suffex,prod)
+    from CondCore.CondDB.CondDB_cfi import CondDB
+    if filename:
+        CondDBReg = CondDB.clone(connect = 'sqlite_file:{}'.format(filename))
+    elif prod:
+        CondDBReg = CondDB.clone(connect = 'frontier://FrontierProd/CMS_CONDITIONS')
+    else:
+        CondDBReg = CondDB.clone(connect = 'frontier://FrontierPrep/CMS_CONDITIONS')
+    
+    process.eleRegres = cms.ESSource("PoolDBESSource",CondDBReg,
+                                     DumpStat=cms.untracked.bool(False),
+                                     toGet = cms.VPSet(
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("electron_eb_ecalOnly_1To300_0p2To2_mean"),
+         tag = cms.string("electron_eb_ecalOnly_1To300_0p2To2_mean_{}".format(suffex))),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("electron_ee_ecalOnly_1To300_0p2To2_mean"),
+         tag = cms.string("electron_ee_ecalOnly_1To300_0p2To2_mean_{}".format(suffex))),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("electron_eb_ecalOnly_1To300_0p0002To0p5_sigma"),
+         tag = cms.string("electron_eb_ecalOnly_1To300_0p0002To0p5_sigma_{}".format(suffex))),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("electron_ee_ecalOnly_1To300_0p0002To0p5_sigma"),
+         tag = cms.string("electron_ee_ecalOnly_1To300_0p0002To0p5_sigma_{}".format(suffex))),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("electron_eb_ecalTrk_1To300_0p2To2_mean"),
+         tag = cms.string("electron_eb_ecalTrk_1To300_0p2To2_mean_{}".format(suffex))),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("electron_ee_ecalTrk_1To300_0p2To2_mean"),
+         tag = cms.string("electron_ee_ecalTrk_1To300_0p2To2_mean_{}".format(suffex))),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("electron_eb_ecalTrk_1To300_0p0002To0p5_sigma"),
+         tag = cms.string("electron_eb_ecalTrk_1To300_0p0002To0p5_sigma_{}".format(suffex))),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("electron_ee_ecalTrk_1To300_0p0002To0p5_sigma"),
+         tag = cms.string("electron_ee_ecalTrk_1To300_0p0002To0p5_sigma_{}".format(suffex))),
+                                     )
+    )
+    
+    process.es_prefer_eleRegres = cms.ESPrefer("PoolDBESSource","eleRegres")
+    return process
+
+
+def readPhoRegresFromDBFile(process,filename=None,suffex="2017UL",prod=False):
+    print "reading in pho regression with tag {} from prod {}".format(suffex,prod)
+    from CondCore.CondDB.CondDB_cfi import CondDB
+    if filename:
+        CondDBReg = CondDB.clone(connect = 'sqlite_file:{}'.format(filename))
+    elif prod:
+        CondDBReg = CondDB.clone(connect = 'frontier://FrontierProd/CMS_CONDITIONS')
+    else:
+        CondDBReg = CondDB.clone(connect = 'frontier://FrontierPrep/CMS_CONDITIONS')
+    process.phoRegres = cms.ESSource("PoolDBESSource",CondDBReg,
+                                     DumpStat=cms.untracked.bool(False),
+                                     toGet = cms.VPSet(
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("photon_eb_ecalOnly_5To300_0p2To2_mean"),
+         tag = cms.string("photon_eb_ecalOnly_5To300_0p2To2_mean_{}".format(suffex))),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("photon_ee_ecalOnly_5To300_0p2To2_mean"),
+         tag = cms.string("photon_ee_ecalOnly_5To300_0p2To2_mean_{}".format(suffex))),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("photon_eb_ecalOnly_5To300_0p0002To0p5_sigma"),
+         tag = cms.string("photon_eb_ecalOnly_5To300_0p0002To0p5_sigma_{}".format(suffex))),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("photon_ee_ecalOnly_5To300_0p0002To0p5_sigma"),
+         tag = cms.string("photon_ee_ecalOnly_5To300_0p0002To0p5_sigma_{}".format(suffex))),
+                                     )
+                                 )
+    process.es_prefer_phoRegres = cms.ESPrefer("PoolDBESSource","phoRegres")
+    return process
+
+def setEventsToProcess(process,eventsToProcess):
+    process.source.eventsToProcess = cms.untracked.VEventRange()
+    for event in eventsToProcess:
+        runnr = event.split(":")[0]
+        eventnr = event.split(":")[2]
+        process.source.eventsToProcess.append('{runnr}:{eventnr}-{runnr}:{eventnr}'.format(runnr=runnr,eventnr=eventnr))
+
+readEleRegresFromDBFile(process,suffex="2017ULV2")
+readPhoRegresFromDBFile(process,suffex="2017ULV2")
+#readEleRegresFromDBFile(process,suffex="2018ULV1")
+#readPhoRegresFromDBFile(process,suffex="2018ULV1")
+#eventsToProcess = ['1:1:9322756']
+#setEventsToProcess(process,eventsToProcess)
+

--- a/TrigNtup/test/egRegTreeMakerSCNewReg.py
+++ b/TrigNtup/test/egRegTreeMakerSCNewReg.py
@@ -1,0 +1,139 @@
+isCrabJob=False #script seds this if its a crab job
+
+# Import configurations
+import FWCore.ParameterSet.Config as cms
+import os
+import sys
+# set up process
+process = cms.Process("HEEP")
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing ('analysis') 
+options.register('isMC',True,options.multiplicity.singleton,options.varType.bool," whether we are running on MC or not")
+options.parseArguments()
+
+print options.inputFiles
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(options.inputFiles),  
+                          )
+
+
+# initialize MessageLogger and output report
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(5000),
+    limit = cms.untracked.int32(10000000)
+)
+
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
+
+#Load geometry
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+from Configuration.AlCa.autoCond import autoCond
+from Configuration.AlCa.GlobalTag import GlobalTag
+
+#gt doesnt really matter much as no reco but nice to get it right
+#process.GlobalTag = GlobalTag(process.GlobalTag, '105X_mc2017_realistic_v5', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '105X_upgrade2018_realistic_v4', '')
+
+
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Geometry.CaloEventSetup.CaloTowerConstituents_cfi")
+process.load("Configuration.StandardSequences.Services_cff")
+
+# set the number of events
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string(options.outputFile)
+)
+
+process.egRegTreeMaker = cms.EDAnalyzer("EGRegTreeMaker",
+                                        verticesTag = cms.InputTag("offlinePrimaryVertices"),
+                                        rhoTag = cms.InputTag("fixedGridRhoFastjetAllTmp"),
+                                        genPartsTag = cms.InputTag("genParticles"),
+                                        puSumTag = cms.InputTag("addPileupInfo"),
+                                        scTag = cms.VInputTag("particleFlowSuperClusterECAL:particleFlowSuperClusterECALBarrel","particleFlowSuperClusterECAL:particleFlowSuperClusterECALEndcapWithPreshower"),
+                                        scAltTag = cms.VInputTag("particleFlowSuperClusterECALNewReg:particleFlowSuperClusterECALBarrel","particleFlowSuperClusterECALNewReg:particleFlowSuperClusterECALEndcapWithPreshower"),
+                                        ecalHitsEBTag = cms.InputTag("reducedEcalRecHitsEB"),
+                                        ecalHitsEETag = cms.InputTag("reducedEcalRecHitsEE"),
+                                        elesTag = cms.InputTag("gedGsfElectrons"),
+                                        phosTag = cms.InputTag("gedPhotons")
+                                        )
+
+process.particleFlowSuperClusterECALNewReg = cms.EDProducer(
+    "EGSuperClusCorrector",
+    colls = cms.VPSet(
+        cms.PSet(
+            coll = cms.InputTag("particleFlowSuperClusterECAL:particleFlowSuperClusterECALBarrel",processName=cms.InputTag.skipCurrentProcess()),
+            outputLabel = cms.string("particleFlowSuperClusterECALBarrel")
+        ),
+        cms.PSet(
+            coll = cms.InputTag("particleFlowSuperClusterECAL:particleFlowSuperClusterECALEndcapWithPreshower",processName=cms.InputTag.skipCurrentProcess()),
+            outputLabel = cms.string("particleFlowSuperClusterECALEndcapWithPreshower"),
+        ),
+    ),
+    regressionCfg = cms.PSet(
+        isHLT = cms.bool(False),
+        applySigmaIetaIphiBug = cms.bool(False),
+        ecalRecHitsEB = cms.InputTag("reducedEcalRecHitsEB"),
+        ecalRecHitsEE = cms.InputTag("reducedEcalRecHitsEE"),
+        regressionKeyEB = cms.string('pfscecal_EBCorrection_offline_v2'),
+        regressionKeyEE = cms.string('pfscecal_EECorrection_offline_v2'),
+        uncertaintyKeyEB = cms.string('pfscecal_EBUncertainty_offline_v2'),
+        uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_offline_v2'),
+        vertexCollection = cms.InputTag("offlinePrimaryVertices")
+    )
+)
+
+process.p = cms.Path(process.particleFlowSuperClusterECALNewReg*process.egRegTreeMaker)
+
+
+process.AODSIMoutput = cms.OutputModule("PoolOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(4),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('AODSIM'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    fileName = cms.untracked.string(options.outputFile.replace(".root","_EDM.root")),
+    outputCommands = cms.untracked.vstring('drop *',
+                                           "keep *_*_*_HEEP",
+                                    )                                           
+                                   )
+#process.out = cms.EndPath(process.AODSIMoutput)
+
+def readSCRegresFromDBFile(process,filename=None):
+    from CondCore.CondDB.CondDB_cfi import CondDB
+    if filename:
+        CondDBReg = CondDB.clone(connect = 'sqlite_file:{}'.format(filename))
+    else:
+        CondDBReg = CondDB.clone(connect = 'frontier://FrontierPrep/CMS_CONDITIONS')
+    process.scRegres = cms.ESSource("PoolDBESSource",CondDBReg,
+                                     DumpStat=cms.untracked.bool(False),
+                                     toGet = cms.VPSet(
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("pfscecal_EBCorrection_offline_v2"),
+         tag = cms.string("pfscecal_EBCorrection_offline_v2_2017UL")),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("pfscecal_EECorrection_offline_v2"),
+         tag = cms.string("pfscecal_EECorrection_offline_v2_2017UL")),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("pfscecal_EBUncertainty_offline_v2"),
+         tag = cms.string("pfscecal_EBUncertainty_offline_v2_2017UL")),
+cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("pfscecal_EEUncertainty_offline_v2"),
+         tag = cms.string("pfscecal_EEUncertainty_offline_v2_2017UL")),
+))
+    process.es_prefer_scRegres = cms.ESPrefer("PoolDBESSource","scRegres")
+    return process
+readSCRegresFromDBFile(process)
+
+
+
+print process.GlobalTag.globaltag

--- a/TrigNtup/test/egRegTreeMakerSCNewReg.py
+++ b/TrigNtup/test/egRegTreeMakerSCNewReg.py
@@ -109,32 +109,31 @@ process.AODSIMoutput = cms.OutputModule("PoolOutputModule",
                                     )                                           
                                    )
 #process.out = cms.EndPath(process.AODSIMoutput)
-
-def readSCRegresFromDBFile(process,filename=None):
+def readSCRegresFromDBFile(process,filename=None,suffex="2017UL"):
     from CondCore.CondDB.CondDB_cfi import CondDB
     if filename:
         CondDBReg = CondDB.clone(connect = 'sqlite_file:{}'.format(filename))
     else:
-        CondDBReg = CondDB.clone(connect = 'frontier://FrontierPrep/CMS_CONDITIONS')
+        CondDBReg = CondDB.clone(connect = 'frontier://FrontierProd/CMS_CONDITIONS')
     process.scRegres = cms.ESSource("PoolDBESSource",CondDBReg,
                                      DumpStat=cms.untracked.bool(False),
                                      toGet = cms.VPSet(
 cms.PSet(record = cms.string("GBRDWrapperRcd"),
          label = cms.untracked.string("pfscecal_EBCorrection_offline_v2"),
-         tag = cms.string("pfscecal_EBCorrection_offline_v2_2017UL")),
+         tag = cms.string("pfscecal_EBCorrection_offline_v2_{}".format(suffex))),
 cms.PSet(record = cms.string("GBRDWrapperRcd"),
          label = cms.untracked.string("pfscecal_EECorrection_offline_v2"),
-         tag = cms.string("pfscecal_EECorrection_offline_v2_2017UL")),
+         tag = cms.string("pfscecal_EECorrection_offline_v2_{}".format(suffex))),
 cms.PSet(record = cms.string("GBRDWrapperRcd"),
          label = cms.untracked.string("pfscecal_EBUncertainty_offline_v2"),
-         tag = cms.string("pfscecal_EBUncertainty_offline_v2_2017UL")),
+         tag = cms.string("pfscecal_EBUncertainty_offline_v2_{}".format(suffex))),
 cms.PSet(record = cms.string("GBRDWrapperRcd"),
          label = cms.untracked.string("pfscecal_EEUncertainty_offline_v2"),
-         tag = cms.string("pfscecal_EEUncertainty_offline_v2_2017UL")),
+         tag = cms.string("pfscecal_EEUncertainty_offline_v2_{}".format(suffex))),
 ))
     process.es_prefer_scRegres = cms.ESPrefer("PoolDBESSource","scRegres")
     return process
-readSCRegresFromDBFile(process)
+readSCRegresFromDBFile(process,suffex="2018UL")
 
 
 

--- a/TrigNtup/test/egRegTreeMakerSCNewReg.py
+++ b/TrigNtup/test/egRegTreeMakerSCNewReg.py
@@ -62,7 +62,9 @@ process.egRegTreeMaker = cms.EDAnalyzer("EGRegTreeMaker",
                                         ecalHitsEBTag = cms.InputTag("reducedEcalRecHitsEB"),
                                         ecalHitsEETag = cms.InputTag("reducedEcalRecHitsEE"),
                                         elesTag = cms.InputTag("gedGsfElectrons"),
-                                        phosTag = cms.InputTag("gedPhotons")
+                                        phosTag = cms.InputTag("gedPhotons"),
+                                        elesAltTag = cms.VInputTag(),
+                                        phosAltTag = cms.VInputTag()
                                         )
 
 process.particleFlowSuperClusterECALNewReg = cms.EDProducer(


### PR DESCRIPTION
This PR adds in changes to simplify testing the regression for the 2018UL regressions. 

It adds a new branch to the ntuples which store alternative electron and photon energies, so the original energy & the new regressed energy can be in the same tree. The ntuples are still considered "V5" as there are no changes which  effect the training step. 



